### PR TITLE
Add beige and sage green palette

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -3,9 +3,10 @@ body {
   margin: 0;
   padding: 0;
   line-height: 1.6;
+  background-color: #f5f5dc; /* beige background */
 }
 nav {
-  background-color: #333;
+  background-color: #9caf88; /* sage green */
   color: #fff;
   padding: 10px;
 }
@@ -14,10 +15,18 @@ nav a {
   margin-right: 15px;
   text-decoration: none;
 }
+a {
+  color: #6b8f71; /* sage tone for links */
+}
+h1 {
+  color: #6b8f71;
+}
 .container {
   max-width: 800px;
   margin: auto;
   padding: 20px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
 }
 
 .dropdown {


### PR DESCRIPTION
## Summary
- refresh palette with beige background and sage green accents
- adjust default link and heading colors
- style content container with subtle background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684633db8c808328adc2645b7d97fb27